### PR TITLE
Create exchage-unit-test

### DIFF
--- a/.github/workflows/exchage-unit-test
+++ b/.github/workflows/exchage-unit-test
@@ -1,0 +1,31 @@
+name: prebidjs-exchange-test
+on: [push]
+jobs:
+  install-js-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm ci
+  test-emx-adapter:
+    runs-on: ubuntu-latest
+    needs: install-js-dependencies
+    steps: 
+      - run: gulp test --file "test/spec/modules/emx_digitalBidAdapter_spec.js"
+  build-prebid-adapter:
+    runs-on: ubuntu-latest
+    needs: test-emx-adapter
+    steps:
+      - run: gulp build --modules=emx_digitalBidAdapter,appnexusBidAdapter
+  test-emx-request:
+    runs-on: ubuntu-latest
+    needs: build-prebid-adapter
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+         with:
+          node-version: '14'
+      - run: node test/helpers/request.js
+    


### PR DESCRIPTION
Workflow that allows for exchange team to inspect header bidding adapter requests before they are sent to header bidding proxy.

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Adding full test suite for exchange engineers to see requests from adapter

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
